### PR TITLE
Add nrows,ncols option to kkplot.subplot_ratio.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.2.0:
+  - New Feature: Add `ncols`,`nrows` to `kkplot.subplot_ratio` that adds multiple ratio plots to the figure.
+
 0.1.0:
   - New Feature: Add `kkplot.xticks` and `kkplot.yticks` as wrappers around `kkplot.ticks` for the corresponding axis.
   - Change: `kkconfig.local` now provides a `load_settings` function instead of directly loading the settings.

--- a/kkplot/__init__.py
+++ b/kkplot/__init__.py
@@ -1,14 +1,39 @@
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 from matplotlib.ticker import MultipleLocator
 
 import numpy as np
 from scipy.stats import beta
 
-def subplot_ratio():
+def subplot_ratio(nrows=1,ncols=1,**kwargs):
     """
     Create a subplot with dimensions useful for making ratio plots.
+
+    The figure is sized such that each ratio plot pair takes up the same area
+    as it would alone.
+
+    Parameters
+    ----------
+    nrows : int
+        Number of ratio plot pairs in the vertical direction.
+    ncols : int
+        Number of ratio plot pairs in the horizontal direction.
+    **kwargs
+        Passed to the `plt.subplots` call.
     """
-    fig, ax=plt.subplots(2,1,sharex=True,squeeze=True,gridspec_kw={'height_ratios':(2,1),'hspace':0.1})
+
+    left=mpl.rcParams['figure.subplot.left']/ncols
+    right=mpl.rcParams['figure.subplot.right']/ncols
+
+    figsize=mpl.rcParams['figure.figsize']
+    figsize[0]*=ncols
+    figsize[1]*=nrows
+
+    fig, ax=plt.subplots(2*nrows,1*ncols,
+                        sharex=True,squeeze=True,
+                        gridspec_kw={'height_ratios':(2,1)*nrows,'hspace':0.1,'left':left,'right':right,'wspace':0.05},
+                        figsize=kwargs.pop('figsize',figsize),
+                        **kwargs)
     return fig, ax
 
 def yeff(ylim=1.1, ax=plt):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = KKHEP
-version = 0.1.0
+version = 0.2.0
 url = https://github.com/kkrizka/KKHEP
 description = Collection of helpful tools to make plots for High Energy Physics.
 long_description = file: README.md


### PR DESCRIPTION
This is for displaying multiple ratio plots in a single figure.

The figure is also resized by nrows,ncols to preserve the size of a single plot.